### PR TITLE
Support Multiple `language_code` Values per Entry for WhisperLiveKit Compatibility

### DIFF
--- a/nllw/languages.py
+++ b/nllw/languages.py
@@ -199,18 +199,32 @@ LANGUAGES = [
     {"name": "Eastern Yiddish", "nllb": "ydd_Hebr", "language_code": "yi"},
     {"name": "Yoruba", "nllb": "yor_Latn", "language_code": "yo"},
     {"name": "Yue Chinese", "nllb": "yue_Hant", "language_code": "yue"},
-    {"name": "Chinese (Simplified)", "nllb": "zho_Hans", "language_code": "zh-CN"},
+    {"name": "Chinese (Simplified)", "nllb": "zho_Hans", "language_code": ["zh-CN", "zh"]},
     {"name": "Chinese (Traditional)", "nllb": "zho_Hant", "language_code": "zh-TW"},
     {"name": "Standard Malay", "nllb": "zsm_Latn", "language_code": "ms"},
     {"name": "Zulu", "nllb": "zul_Latn", "language_code": "zu"},
 ]
 
 NAME_TO_NLLB = {lang["name"]: lang["nllb"] for lang in LANGUAGES}
-NAME_TO_LANGUAGE_CODE = {lang["name"]: lang["language_code"] for lang in LANGUAGES}
-LANGUAGE_CODE_TO_NLLB = {lang["language_code"]: lang["nllb"] for lang in LANGUAGES}
-NLLB_TO_LANGUAGE_CODE = {lang["nllb"]: lang["language_code"] for lang in LANGUAGES}
-LANGUAGE_CODE_TO_NAME = {lang["language_code"]: lang["name"] for lang in LANGUAGES}
 NLLB_TO_NAME = {lang["nllb"]: lang["name"] for lang in LANGUAGES}
+
+
+# Helper function to normalize language_code to list
+def _get_language_codes(lang):
+    codes = lang["language_code"]
+    return codes if isinstance(codes, list) else [codes]
+
+
+# Build dictionaries that support multiple language_codes per entry
+NAME_TO_LANGUAGE_CODE = {lang["name"]: _get_language_codes(lang)[0] for lang in LANGUAGES}
+NLLB_TO_LANGUAGE_CODE = {lang["nllb"]: _get_language_codes(lang)[0] for lang in LANGUAGES}
+
+LANGUAGE_CODE_TO_NLLB = {}
+LANGUAGE_CODE_TO_NAME = {}
+for lang in LANGUAGES:
+    for code in _get_language_codes(lang):
+        LANGUAGE_CODE_TO_NLLB[code] = lang["nllb"]
+        LANGUAGE_CODE_TO_NAME[code] = lang["name"]
 
 
 def get_nllb_code(language_code_code):
@@ -241,14 +255,20 @@ def get_language_name_by_nllb(nllb_code):
     return NLLB_TO_NAME.get(nllb_code)
 
 
+def _match_language_code(lang, identifier):
+    """Check if identifier matches any of the language codes (case-insensitive)."""
+    codes = _get_language_codes(lang)
+    identifier_lower = identifier.lower()
+    return any(code == identifier or code.lower() == identifier_lower for code in codes)
+
+
 def get_language_info(identifier, identifier_type="auto"):
     if identifier_type == "auto":
         for lang in LANGUAGES:
-            if (lang["name"].lower() == identifier.lower() or 
-                lang["nllb"] == identifier or 
-                lang["nllb"].lower() == identifier.lower() or
-                lang["language_code"] == identifier or
-                lang["language_code"].lower() == identifier.lower()):
+            if (lang["name"].lower() == identifier.lower() or
+                    lang["nllb"] == identifier or
+                    lang["nllb"].lower() == identifier.lower() or
+                    _match_language_code(lang, identifier)):
                 return lang
     elif identifier_type == "name":
         for lang in LANGUAGES:
@@ -260,7 +280,7 @@ def get_language_info(identifier, identifier_type="auto"):
                 return lang
     elif identifier_type == "language_code":
         for lang in LANGUAGES:
-            if lang["language_code"] == identifier or lang["language_code"].lower() == identifier.lower():
+            if _match_language_code(lang, identifier):
                 return lang
     
     return None
@@ -286,4 +306,7 @@ def list_all_nllb_codes():
 
 
 def list_all_language_code_codes():
-    return [lang["language_code"] for lang in LANGUAGES]
+    codes = []
+    for lang in LANGUAGES:
+        codes.extend(_get_language_codes(lang))
+    return codes


### PR DESCRIPTION
## Problem Description

When using WhisperLiveKit with NLLW for voice translation, the `--lan` parameter is passed to both Whisper (speech recognition) and NLLW (translation).  https://github.com/QuentinFuxa/NoLanguageLeftWaiting/issues/2

**Issue**: Whisper only supports `zh` as the Chinese language code, while NLLW previously only supported `zh-CN`, causing incompatibility.

### Error Reproduction

```bash
# Using zh-CN: Whisper throws error
python -m whisperlivekit.basic_server --lan zh-CN --target-language eng_Latn
# Error: Unsupported language: zh-cn

# Using zh: NLLW throws error
python -m whisperlivekit.basic_server --lan zh --target-language eng_Latn
# Error: Unknown language identifier: zh
```

### Root Cause

| System | Supported Chinese Code |
|--------|------------------------|
| Whisper | `zh` |
| NLLW | `zh-CN` |

The two systems have incompatible language codes.

## Solution

Extend the `language_code` field to support list type, allowing a single language entry to map to multiple language codes:

```python
# Before: single language_code
{"name": "Chinese (Simplified)", "nllb": "zho_Hans", "language_code": "zh-CN"}

# After: support list, compatible with both zh and zh-CN
{"name": "Chinese (Simplified)", "nllb": "zho_Hans", "language_code": ["zh-CN", "zh"]}
```

## Modified Files

- `nllw/languages.py`

## Changes

### 1. Data Structure Change

```diff
-   {"name": "Chinese (Simplified)", "nllb": "zho_Hans", "language_code": "zh-CN"},
+   {"name": "Chinese (Simplified)", "nllb": "zho_Hans", "language_code": ["zh-CN", "zh"]},
```

### 2. New Helper Functions

```python
def _get_language_codes(lang):
    """Convert language_code to list, compatible with both string and list formats"""
    codes = lang["language_code"]
    return codes if isinstance(codes, list) else [codes]


def _match_language_code(lang, identifier):
    """Check if identifier matches any language_code (case-insensitive)"""
    codes = _get_language_codes(lang)
    identifier_lower = identifier.lower()
    return any(code == identifier or code.lower() == identifier_lower for code in codes)
```

### 3. Modified Dictionary Building Logic

```python
# Support multiple language_codes mapping to the same nllb code
LANGUAGE_CODE_TO_NLLB = {}
LANGUAGE_CODE_TO_NAME = {}
for lang in LANGUAGES:
    for code in _get_language_codes(lang):
        LANGUAGE_CODE_TO_NLLB[code] = lang["nllb"]
        LANGUAGE_CODE_TO_NAME[code] = lang["name"]
```

### 4. Modified Lookup Functions

`get_language_info()` and `list_all_language_code_codes()` functions have been updated to support list type `language_code`.

## Test Verification

```bash
python -c "
from nllw.languages import convert_to_nllb_code, LANGUAGE_CODE_TO_NLLB

print('zh ->', convert_to_nllb_code('zh'))       # zho_Hans
print('zh-CN ->', convert_to_nllb_code('zh-CN')) # zho_Hans
print('ZH ->', convert_to_nllb_code('ZH'))       # zho_Hans (case-insensitive)
"
```

After the fix, the following command works correctly:

```bash
python -m whisperlivekit.basic_server --lan zh --target-language eng_Latn
```

## Impact

- **Backward compatible**: `zh-CN` still works, no changes needed for existing code
- **New support**: `zh` is now recognized
- **Extensible**: Other languages can support multiple codes by changing `language_code` to a list
- **No impact**: Entries with single `language_code` value need no modification

## Design Advantages

Compared to simply adding duplicate entries:
```python
# Option A (not recommended): add duplicate entries
{"name": "Chinese (Simplified)", "nllb": "zho_Hans", "language_code": "zh-CN"},
{"name": "Chinese", "nllb": "zho_Hans", "language_code": "zh"},  # duplicate
```

This solution is more elegant:
```python
# Option B (this PR): support list
{"name": "Chinese (Simplified)", "nllb": "zho_Hans", "language_code": ["zh-CN", "zh"]},
```

- No duplicate data
- Clearly expresses "multiple codes for the same language" semantics
- Easy to extend for other languages

## Related Projects

- [WhisperLiveKit](https://github.com/QuentinFuxa/WhisperLiveKit) - Real-time speech recognition
- Whisper language code reference: [Whisper tokenizer](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py)
